### PR TITLE
[WIP] BlazingSQL q28: Remove bc.partition(), instead using ORDER BY

### DIFF
--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -312,12 +312,9 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (0)
         AND pr_review_content IS NOT NULL
-        -- in a near future we want to use ORDER BY again
-        --ORDER BY pr_review_sk
+        ORDER BY pr_review_sk
     """
     test_data = bc.sql(query1)
-    # in a near future we want to reuse ORDER BY instead of bc.partition()
-    test_data = bc.partition(test_data, by=["pr_review_sk"])
 
     # 90 % of data
     query2 = """
@@ -328,11 +325,9 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (1,2,3,4,5,6,7,8,9)
         AND pr_review_content IS NOT NULL
-        --ORDER BY pr_review_sk
+        ORDER BY pr_review_sk
     """
     train_data = bc.sql(query2)
-    # in a near future we want to reuse ORDER BY instead of bc.partition()
-    train_data = bc.partition(train_data, by=["pr_review_sk"])
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -325,9 +325,12 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (1,2,3,4,5,6,7,8,9)
         AND pr_review_content IS NOT NULL
-        ORDER BY pr_review_sk
+        --ORDER BY pr_review_sk
     """
     train_data = bc.sql(query2)
+
+    # in a near future we want to reuse ORDER BY instead of bc.partition()
+    train_data = bc.partition(train_data, by=["pr_review_sk"])
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -325,13 +325,9 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (1,2,3,4,5,6,7,8,9)
         AND pr_review_content IS NOT NULL
-        --ORDER BY pr_review_sk
+        ORDER BY pr_review_sk
     """
     train_data = bc.sql(query2)
-
-    # in a near future we want to reuse ORDER BY instead of bc.partition()
-    train_data = train_data.persist()
-    train_data = bc.partition(train_data, by=["pr_review_sk"])
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -330,6 +330,7 @@ def main(data_dir, client, bc, config):
     train_data = bc.sql(query2)
 
     # in a near future we want to reuse ORDER BY instead of bc.partition()
+    train_data = train_data.persist()
     train_data = bc.partition(train_data, by=["pr_review_sk"])
 
     final_data, acc, prec, cmat = post_etl_processing(
@@ -343,7 +344,8 @@ def main(data_dir, client, bc, config):
         "cmat": cmat,
         "output_type": "supervised",
     }
-
+    del test_data
+    del train_data
     return payload
 
 


### PR DESCRIPTION
This PR remove the use of `bc.partition()` functions. Instead uses `ORDER BY` statements for both queries.