### PR TITLE
[REVIEW] Unpin dask/distributed and remove nightly pytorch default environment

### DIFF
--- a/conda/rapids-tpcx-bb.yml
+++ b/conda/rapids-tpcx-bb.yml
@@ -2,9 +2,7 @@ channels:
   - blazingsql-nightly/label/cuda10.2
   - rapidsai-nightly
   - nvidia
-  - pytorch-nightly
   - conda-forge
-  - blazingsql-nightly
   - defaults
 
 dependencies:
@@ -27,13 +25,11 @@ dependencies:
   - psutil
   - ipykernel
   - jupyterlab
-  - torchvision
-  - pytorch
   - gspread
   - oauth2client
   - pip
   - pip:
     - transformers
     - jupyter-server-proxy
-    - git+https://github.com/dask/dask.git@2b45fdb9bcf4a98e54b8fa2c7c3da1410a73bea3
-    - git+https://github.com/dask/distributed.git@2b43b402c19b278a1e2fe7e1bf7718452b2fe007
+    - git+https://github.com/dask/dask.git
+    - git+https://github.com/dask/distributed.git

--- a/conda/rapids-tpcx-bb.yml
+++ b/conda/rapids-tpcx-bb.yml
@@ -29,7 +29,6 @@ dependencies:
   - oauth2client
   - pip
   - pip:
-    - transformers
     - jupyter-server-proxy
     - git+https://github.com/dask/dask.git
     - git+https://github.com/dask/distributed.git


### PR DESCRIPTION
This PR:
- Unpins dask and distributed from the default conda environment
- Removes nightly pytorch from the default environment, as we are not using it by default
- Also removes a redundant blazingsql channel