### PR TITLE
[REVIEW] Update bsql conda to use the main channel

### DIFF
--- a/conda/rapids-tpcx-bb.yml
+++ b/conda/rapids-tpcx-bb.yml
@@ -1,5 +1,5 @@
 channels:
-  - blazingsql-nightly/label/cuda10.2
+  - blazingsql-nightly
   - rapidsai-nightly
   - nvidia
   - conda-forge


### PR DESCRIPTION
This PR:
- Updates the BSQL conda channel to not use an explicit label

This closes https://github.com/rapidsai/gpu-bdb/issues/141