### PR TITLE
[REVIEW] Use stable release of dask and distributed

### DIFF
--- a/conda/rapids-tpcx-bb.yml
+++ b/conda/rapids-tpcx-bb.yml
@@ -13,6 +13,8 @@ dependencies:
   - dask-cuda
   - dask-cudf
   - cuml
+  - dask
+  - distributed
   - ucx-py
   - ucx-proc=*=gpu
   - blazingsql
@@ -30,5 +32,3 @@ dependencies:
   - pip
   - pip:
     - jupyter-server-proxy
-    - git+https://github.com/dask/dask.git
-    - git+https://github.com/dask/distributed.git

--- a/tpcx_bb/benchmark_runner/slurm/rapids-tpcx-bb-cuda11.yml
+++ b/tpcx_bb/benchmark_runner/slurm/rapids-tpcx-bb-cuda11.yml
@@ -1,5 +1,5 @@
 channels:
-  - blazingsql-nightly/label/cuda11.0
+  - blazingsql-nightly
   - rapidsai-nightly
   - nvidia
   - conda-forge
@@ -13,6 +13,8 @@ dependencies:
   - dask-cuda
   - dask-cudf
   - cuml
+  - dask
+  - distributed
   - blazingsql
   - scipy
   - scikit-learn
@@ -27,5 +29,3 @@ dependencies:
   - pip
   - pip:
     - jupyter-server-proxy
-    - git+https://github.com/dask/dask.git
-    - git+https://github.com/dask/distributed.git


### PR DESCRIPTION
This PR:
- Uses the stable dask and distributed in the default conda environments due to the ongoing scheduler work