### PR TITLE
[REVIEW] BlazingSQL Q28 - Remove bc.partition(), using ORDER BY

### DIFF
--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -313,13 +313,9 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (0)
         AND pr_review_content IS NOT NULL
-        -- in a near future we want to use ORDER BY again
-        --ORDER BY pr_review_sk
+        ORDER BY pr_review_sk
     """
     test_data = bc.sql(query1)
-    test_data = test_data.sort_values(
-        by=["pr_review_sk"]
-    ).reset_index(drop=True)
 
     # 90 % of data
     query2 = """
@@ -330,13 +326,12 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (1,2,3,4,5,6,7,8,9)
         AND pr_review_content IS NOT NULL
-        -- in a near future we want to use ORDER BY again
-        --ORDER BY pr_review_sk
+        ORDER BY pr_review_sk
     """
-    train_data = bc.sql(query2)
-    train_data = train_data.sort_values(
-        by=["pr_review_sk"]
-    ).reset_index(drop=True)
+    # we want to get more samples than the default value
+    config_options = {}
+    config_options['ORDER_BY_SAMPLES_RATIO'] = 0.002
+    train_data = bc.sql(query2, config_options=config_options)
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -328,10 +328,7 @@ def main(data_dir, client, bc, config):
         AND pr_review_content IS NOT NULL
         ORDER BY pr_review_sk
     """
-    # we want to get more samples than the default value
-    config_options = {}
-    config_options['ORDER_BY_SAMPLES_RATIO'] = 0.002
-    train_data = bc.sql(query2, config_options=config_options)
+    train_data = bc.sql(query2)
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data

--- a/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
+++ b/tpcx_bb/queries/q28/tpcx_bb_query_28_sql.py
@@ -317,8 +317,9 @@ def main(data_dir, client, bc, config):
         --ORDER BY pr_review_sk
     """
     test_data = bc.sql(query1)
-    # in a near future we want to reuse ORDER BY instead of bc.partition()
-    test_data = bc.partition(test_data, by=["pr_review_sk"])
+    test_data = test_data.sort_values(
+        by=["pr_review_sk"]
+    ).reset_index(drop=True)
 
     # 90 % of data
     query2 = """
@@ -329,11 +330,13 @@ def main(data_dir, client, bc, config):
         FROM product_reviews
         WHERE mod(pr_review_sk, 10) IN (1,2,3,4,5,6,7,8,9)
         AND pr_review_content IS NOT NULL
+        -- in a near future we want to use ORDER BY again
         --ORDER BY pr_review_sk
     """
     train_data = bc.sql(query2)
-    # in a near future we want to reuse ORDER BY instead of bc.partition()
-    train_data = bc.partition(train_data, by=["pr_review_sk"])
+    train_data = train_data.sort_values(
+        by=["pr_review_sk"]
+    ).reset_index(drop=True)
 
     final_data, acc, prec, cmat = post_etl_processing(
         client=client, train_data=train_data, test_data=test_data


### PR DESCRIPTION
This PR closes #151 for now setting up the `ORDER_BY_SAMPLES_RATIO` value to` 0.002`  to the second `sql`. `ORDER BY` will be re-factorized in a future.  It shows **Correctness Assertion True** at sf 1K

```
Accuracy: 0.9984961971138552
Precision: 0.9971834870532952
Confusion Matrix: [[5.20660e+04 1.30000e+01 1.91000e+02]
 [6.20000e+01 3.54210e+04 1.30000e+02]
 [2.07000e+02 7.30000e+01 3.61364e+05]]
/home/christianc/miniconda3/envs/bsql-tpcx/lib/python3.7/site-packages/cudf/core/column/string.py:731: UserWarning: `n` parameter is not supported when `pat` and `repl` are list-like inputs
  "`n` parameter is not supported when "
Supervised Learning Query
Precisiom delta percent: 2.7047481485066505
AUC delta percent: 2.839950503852733
Precision higher/similar: True
AUC higher/similar: True
Correctness Assertion True
```

This also closes https://github.com/rapidsai/gpu-bdb/issues/150