### PR TITLE
Use cupy 8

### DIFF
--- a/conda/rapids-tpcx-bb.yml
+++ b/conda/rapids-tpcx-bb.yml
@@ -20,7 +20,7 @@ dependencies:
   - blazingsql
   - scipy
   - scikit-learn
-  - cupy=7
+  - cupy=8
   - spacy
   - oauth2client
   - asyncssh


### PR DESCRIPTION
30/30 TCP queries succeed at SF1K in the 2020-12-11 nightlies.

This closes https://github.com/rapidsai/gpu-bdb/issues/156