### PR TITLE
[REVIEW] Updating config_option: add PROTOCOL, remove ORDER_BY_SAMPLES_RATIO

### DIFF
--- a/tpcx_bb/xbb_tools/cluster_startup.py
+++ b/tpcx_bb/xbb_tools/cluster_startup.py
@@ -39,7 +39,6 @@ def get_bsql_config_options():
     config_options['MAX_KERNEL_RUN_THREADS'] = os.environ.get("MAX_KERNEL_RUN_THREADS", 3)
     config_options['TABLE_SCAN_KERNEL_NUM_THREADS'] = os.environ.get("TABLE_SCAN_KERNEL_NUM_THREADS", 1)
     config_options['MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE'] = os.environ.get("MAX_NUM_ORDER_BY_PARTITIONS_PER_NODE", 20)
-    config_options['ORDER_BY_SAMPLES_RATIO'] = os.environ.get("ORDER_BY_SAMPLES_RATIO", 0.0002)
     config_options['NUM_BYTES_PER_ORDER_BY_PARTITION'] = os.environ.get("NUM_BYTES_PER_ORDER_BY_PARTITION", 400000000)
     config_options['MAX_ORDER_BY_SAMPLES_PER_NODE'] = os.environ.get("MAX_ORDER_BY_SAMPLES_PER_NODE", 10000)
     config_options['MAX_SEND_MESSAGE_THREADS'] = os.environ.get("MAX_SEND_MESSAGE_THREADS", 20)
@@ -50,6 +49,7 @@ def get_bsql_config_options():
     config_options['BLAZING_CACHE_DIRECTORY'] = os.environ.get("BLAZING_CACHE_DIRECTORY", '/tmp/')
     config_options['LOGGING_LEVEL'] = os.environ.get("LOGGING_LEVEL", "trace")
     config_options['MAX_JOIN_SCATTER_MEM_OVERHEAD'] = os.environ.get("MAX_JOIN_SCATTER_MEM_OVERHEAD", 500000000)
+    config_options['PROTOCOL'] = os.environ.get("PROTOCOL", "TCP")
 
     return config_options
 

--- a/tpcx_bb/xbb_tools/cluster_startup.py
+++ b/tpcx_bb/xbb_tools/cluster_startup.py
@@ -49,7 +49,7 @@ def get_bsql_config_options():
     config_options['BLAZING_CACHE_DIRECTORY'] = os.environ.get("BLAZING_CACHE_DIRECTORY", '/tmp/')
     config_options['LOGGING_LEVEL'] = os.environ.get("LOGGING_LEVEL", "trace")
     config_options['MAX_JOIN_SCATTER_MEM_OVERHEAD'] = os.environ.get("MAX_JOIN_SCATTER_MEM_OVERHEAD", 500000000)
-    config_options['PROTOCOL'] = os.environ.get("PROTOCOL", "TCP")
+    config_options['PROTOCOL'] = os.environ.get("PROTOCOL", "AUTO")
 
     return config_options
 


### PR DESCRIPTION
This PR removes the `ORDER_BY_SAMPLES_RATIO` `config_option` as was removed from `BlazingSQL`, also add a new one called `PROTOCOL` which by default is defined as `AUTO`.  To have more context about this parameter, please check it out this merged PR https://github.com/BlazingDB/blazingsql/pull/1285.