### PR TITLE
Use rmm for all cupy allocations in client and worker processes

### DIFF
--- a/tpcx_bb/xbb_tools/cluster_startup.py
+++ b/tpcx_bb/xbb_tools/cluster_startup.py
@@ -104,6 +104,12 @@ def attach_to_cluster(config, create_blazing_context=False):
     # Get ucx config variables
     ucx_config = client.submit(_get_ucx_config).result()
     config.update(ucx_config)
+    
+    # CuPy should use RMM on all worker and client processes
+    import cupy as cp
+    import rmm
+    cp.cuda.set_allocator(rmm.rmm_cupy_allocator)
+    client.run(cp.cuda.set_allocator, rmm.rmm_cupy_allocator)
 
     # Save worker information
     # Assumes all GPUs are the same size


### PR DESCRIPTION
This PR:
- Sets RMM as the memory resource for cupy allocations

Imports are happening inside the scope of the `attach_to_cluster` function to avoid any potential ordering issues related to which library first touches the CUDA driver (not sure this is necessary, but have seen some odd behavior).