### PR TITLE
Enforce slurm worker job dependency on scheduler job

### DIFF
--- a/gpu_bdb/benchmark_runner/slurm/run.sh
+++ b/gpu_bdb/benchmark_runner/slurm/run.sh
@@ -17,6 +17,7 @@ srun \
     --account $ACCOUNT \
     --partition $PARTITION \
     --nodes 1 \
+    --job-name gpubdb-sched \
     --time 120 \
     --container-mounts $DATA_PATH:$MOUNT_PATH,$HOME:$HOME \
     --container-image=$IMAGE \

--- a/gpu_bdb/benchmark_runner/slurm/run.sh
+++ b/gpu_bdb/benchmark_runner/slurm/run.sh
@@ -24,6 +24,8 @@ srun \
 
 sleep 15
 
+SCHEDULER_JOBID=$(sacct --starttime $(date -d "-30 seconds" +%FT%H:%M:%S) --endtime $(date -d "+1 days" +%F) -n -X --format jobid --name gpubdb-sched)
+
 if [ "$WORKER_NODES" -gt "0" ]
 then
     srun \
@@ -31,6 +33,7 @@ then
         --partition $PARTITION \
         --nodes $WORKER_NODES \
         --time 120 \
+        --dependency after:$SCHEDULER_JOBID \
         --container-mounts $DATA_PATH:$MOUNT_PATH,$HOME:$HOME \
         --container-image $IMAGE \
         bash -c "$GPU_BDB_HOME/gpu_bdb/benchmark_runner/slurm/spawn-workers.sh"


### PR DESCRIPTION
This PR:
- Works around srun to get the scheduler/client job id and use that as a dependency for the worker job.

We should eventually switch to using sbatch which will let us use the --parsable option to capture the scheduler/client node job id.