### PR TITLE
Slurm backfill updates

### DIFF
--- a/gpu_bdb/benchmark_runner/slurm/run.sh
+++ b/gpu_bdb/benchmark_runner/slurm/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ACCOUNT=rapids
-PARTITION=partition
+PARTITION=backfill
 NODES=1
 let "WORKER_NODES = $NODES - 1"
 
@@ -33,6 +33,7 @@ then
         --account $ACCOUNT \
         --partition $PARTITION \
         --nodes $WORKER_NODES \
+        --job-name gpubdb-workers \
         --time 120 \
         --dependency after:$SCHEDULER_JOBID \
         --container-mounts $DATA_PATH:$MOUNT_PATH,$HOME:$HOME \

--- a/gpu_bdb/benchmark_runner/slurm/spawn-workers.sh
+++ b/gpu_bdb/benchmark_runner/slurm/spawn-workers.sh
@@ -9,6 +9,10 @@ export INTERFACE="enp97s0f1"
 export BLAZING_ALLOCATOR_MODE="existing"
 export BLAZING_LOGGING_DIRECTORY=/gpu-bdb-data/gpu-bdb/blazing_log
 
+# sleep for 15 seconds to handle cases in which this job spins up workers
+# before the scheduler is ready
+sleep 15
+
 echo $LOGDIR
 echo ls -l $LOGDIR
 bash $GPU_BDB_HOME/gpu_bdb/cluster_configuration/cluster-startup-slurm.sh &


### PR DESCRIPTION
This PR:
- Defaults the partition to Slurm backfill, adds a job name for the worker job, and adds a sleep to handle simultaneous allocations