### PR TITLE
Pin spacy to 2.3

### DIFF
--- a/conda/rapids-gpu-bdb.yml
+++ b/conda/rapids-gpu-bdb.yml
@@ -21,7 +21,7 @@ dependencies:
   - scipy
   - scikit-learn
   - cupy=8
-  - spacy
+  - spacy=2.3
   - oauth2client
   - asyncssh
   - psutil

--- a/gpu_bdb/benchmark_runner/slurm/rapids-gpu-bdb-cuda11.yml
+++ b/gpu_bdb/benchmark_runner/slurm/rapids-gpu-bdb-cuda11.yml
@@ -18,7 +18,7 @@ dependencies:
   - blazingsql
   - scipy
   - scikit-learn
-  - spacy
+  - spacy=2.3
   - oauth2client
   - asyncssh
   - psutil


### PR DESCRIPTION
This PR:
- Pins spacy to 2.3 in the conda environments.


This closes https://github.com/rapidsai/gpu-bdb/issues/188