### PR TITLE
Fixes query 15 column renaming

### DIFF
--- a/gpu_bdb/queries/q15/gpu_bdb_query_15.py
+++ b/gpu_bdb/queries/q15/gpu_bdb_query_15.py
@@ -124,8 +124,8 @@ def main(client, config):
     regression_groups = agg_df.groupby(["cat"]).agg(
         {"x": ["count", "sum"], "xx": ["sum"], "xy": ["sum"], "y": ["count", "sum"]}
     )
-    regression_groups = regression_groups.rename(
-        columns={
+    regression_groups.columns = regression_groups.columns.map(
+        {
             ("x", "count"): "count_x",
             ("x", "sum"): "sum_x",
             ("xx", "sum"): "sum_xx",


### PR DESCRIPTION
The rename function changed to only support renaming one level at a time in a multi-index, so this implements the same logic as before using the `columns` attribute.