### PR TITLE
Use fillna in sessionization to account for updated cudf null handling in binaryops

### DIFF
--- a/gpu_bdb/bdb_tools/sessionization.py
+++ b/gpu_bdb/bdb_tools/sessionization.py
@@ -50,8 +50,9 @@ def get_session_id(df, keep_cols, time_out):
     """
 
     df["user_change_flag"] = df["wcs_user_sk"].diff(periods=1) != 0
-    df["time_delta"] = df["tstamp_inSec"].diff(periods=1)
+    df["user_change_flag"] = df["user_change_flag"].fillna(True)
     df["session_timeout_flag"] = df["tstamp_inSec"].diff(periods=1) > time_out
+    df["session_timeout_flag"] = df["session_timeout_flag"].fillna(False)
 
     df["session_change_flag"] = df["session_timeout_flag"] | df["user_change_flag"]
 

--- a/gpu_bdb/queries/q08/gpu_bdb_query_08.py
+++ b/gpu_bdb/queries/q08/gpu_bdb_query_08.py
@@ -112,6 +112,7 @@ def get_session_id(df):
     """
 
     df["user_change_flag"] = df["wcs_user_sk"].diff(periods=1) != 0
+    df["user_change_flag"] = df["user_change_flag"].fillna(True)
     df["session_change_flag"] = df["review_flag"] | df["user_change_flag"]
 
     df = df.reset_index(drop=True)

--- a/gpu_bdb/queries/q08/gpu_bdb_query_08_sql.py
+++ b/gpu_bdb/queries/q08/gpu_bdb_query_08_sql.py
@@ -71,6 +71,7 @@ def get_session_id(df):
     """
 
     df["user_change_flag"] = df["wcs_user_sk"].diff(periods=1) != 0
+    df["user_change_flag"] = df["user_change_flag"].fillna(True)
     df["session_change_flag"] = df["review_flag"] | df["user_change_flag"]
 
     df = df.reset_index(drop=True)


### PR DESCRIPTION
This PR:
- Adds a `fillna` op after the `diff` calls in sessionization. We use these to create masks for filtering, so they are filled with True or False as appropriate based on the query logic
- Also removes a redundant diff() call and column `time_delta`


This closes https://github.com/rapidsai/gpu-bdb/issues/195