### PR TITLE
[REVIEW] Add file_format parameter for the sentiment files

### DIFF
--- a/gpu_bdb/queries/q10/gpu_bdb_query_10_sql.py
+++ b/gpu_bdb/queries/q10/gpu_bdb_query_10_sql.py
@@ -91,10 +91,12 @@ def main(data_dir, client, bc, config):
     sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
     bc.create_table('negative_sentiment',
                     os.path.join(sentiment_dir, "negativeSentiment.txt"),
-                    names="sentiment_word")
+                    names="sentiment_word",
+                    file_format="csv")
     bc.create_table('positive_sentiment',
                     os.path.join(sentiment_dir, "positiveSentiment.txt"),
-                    names="sentiment_word")
+                    names="sentiment_word",
+                    file_format="csv")
 
     word_df = word_df.persist()
     wait(word_df)

--- a/gpu_bdb/queries/q18/gpu_bdb_query_18_sql.py
+++ b/gpu_bdb/queries/q18/gpu_bdb_query_18_sql.py
@@ -254,12 +254,11 @@ def main(data_dir, client, bc, config):
     # We extracted it from bigbenchqueriesmr.jar
     # Need to pass the absolute path for this txt file
     sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
-    bc.create_table(
-        "sent_df",
-        os.path.join(sentiment_dir, "negativeSentiment.txt"),
-        names=["sentiment_word"],
-        dtype=["str"],
-    )
+    bc.create_table("sent_df",
+                    os.path.join(sentiment_dir, "negativeSentiment.txt"),
+                    names=["sentiment_word"],
+                    dtype=["str"],
+                    file_format="csv")
 
     word_df = word_df.persist()
     wait(word_df)

--- a/gpu_bdb/queries/q19/gpu_bdb_query_19_sql.py
+++ b/gpu_bdb/queries/q19/gpu_bdb_query_19_sql.py
@@ -119,7 +119,9 @@ def main(data_dir, client, bc, config):
     sentiment_dir = os.path.join(config["data_dir"], "sentiment_files")
     bc.create_table('sent_df',
                     os.path.join(sentiment_dir, "negativeSentiment.txt"),
-                    names=['sentiment_word'], dtype=['str'])
+                    names=['sentiment_word'],
+                    dtype=['str'],
+                    file_format="csv")
 
     sentences = sentences.persist()
     wait(sentences)


### PR DESCRIPTION
This PR closes #201 .
It add the `file_format` parameter when creating tables that comes from sentiment files  (`.txt` format in these cases) 