### PR TITLE
Write parquet with decimal columns in load_test

### DIFF
--- a/gpu_bdb/bdb_tools/readers.py
+++ b/gpu_bdb/bdb_tools/readers.py
@@ -127,7 +127,7 @@ class ParquetReader(Reader):
 
         if (table in SMALL_TABLES) or (table in SUPER_SMALL_TABLES):
             df = df.repartition(npartitions=1)
-        return df
+        return df.compute()
 
 
 class ORCReader(Reader):


### PR DESCRIPTION
This enables using `load_test` to create parquet files with `decimal` columns as well as reading in parquet files with `decimal` columns for running queries. However, as the csv reader/writer doesn't support `decimal` yet, the `decimal` values have to be read in as `float` and cast to `decimal` before they're written to parquet.