### PR TITLE
Run all queries sequentially instead of repeatedly

### DIFF
--- a/conda/rapids-gpu-bdb.yml
+++ b/conda/rapids-gpu-bdb.yml
@@ -5,8 +5,8 @@ channels:
 
 dependencies:
   - python=3.8
-  - cudatoolkit=11.0
-  - cudf
+  - cudatoolkit=11.2
+  - cudf=21.08
   - rmm
   - dask-cuda
   - dask-cudf

--- a/gpu_bdb/bdb_tools/utils.py
+++ b/gpu_bdb/bdb_tools/utils.py
@@ -904,7 +904,7 @@ def push_payload_to_googlesheet(config):
       payload = build_benchmark_googlesheet_payload(config)
       s = gc.open(config["sheet"])
       tab = s.worksheet(config["tab"])
-      tab.append_row(payload, value_input_option='USER_ENTERED')
+      tab.append_row(payload, value_input_option='USER_ENTERED', table_range='A2')
 
 
 #################################

--- a/gpu_bdb/benchmark_runner.py
+++ b/gpu_bdb/benchmark_runner.py
@@ -21,6 +21,7 @@ def load_query(qnum, fn):
     return mod.main
 
 
+#dask_qnums = [str(i).zfill(2) for i in range(1, 31)]
 dask_qnums = [str(i).zfill(2) for i in range(1, 31)]
 bsql_qnums = [str(i).zfill(2) for i in range(1, 31)]
 
@@ -79,19 +80,21 @@ if __name__ == "__main__":
     # Run Pure Dask Queries
     if len(dask_qnums) > 0:
         print("Pure Dask Queries")
-        for qnum, q_func in dask_queries.items():
-            print(qnum)
+        for r in range(N_REPEATS):
+            for qnum, q_func in dask_queries.items():
+                print(qnum)
 
-            qpath = f"{base_path}/queries/q{qnum}/"
-            os.chdir(qpath)
-            if os.path.exists("current_query_num.txt"):
-                os.remove("current_query_num.txt")
-            with open("current_query_num.txt", "w") as fp:
-                fp.write(qnum)
+                qpath = f"{base_path}/queries/q{qnum}/"
+                os.chdir(qpath)
+                if os.path.exists("current_query_num.txt"):
+                    os.remove("current_query_num.txt")
+                with open("current_query_num.txt", "w") as fp:
+                    fp.write(qnum)
 
-            for r in range(N_REPEATS):
                 run_query(config=config, client=client, query_func=q_func)
-                client.run(gc.collect)
-                client.run_on_scheduler(gc.collect)
-                gc.collect()
-                time.sleep(3)
+
+            #run GC after each full benchmark run
+            client.run(gc.collect)
+            client.run_on_scheduler(gc.collect)
+            gc.collect()
+            time.sleep(3)


### PR DESCRIPTION
benchmark_runner now runs all queries sequentially before repeating, and runs GC after a full run instead of after each query.

Fixes Google Sheets row insert location. See accepted answer [here](https://stackoverflow.com/questions/60793155/gspread-append-row-appending-data-to-different-column).