### PR TITLE
WIP: log dask task stream and rmm events into results dir

### DIFF
--- a/gpu_bdb/bdb_tools/__init__.py
+++ b/gpu_bdb/bdb_tools/__init__.py
@@ -1,1 +1,4 @@
 # Copyright (c) 2020, NVIDIA CORPORATION.
+
+from .rmm_monitor import RMMResourceMonitor
+from .dasktasklogger import DaskTaskLogger

--- a/gpu_bdb/bdb_tools/dasktasklogger.py
+++ b/gpu_bdb/bdb_tools/dasktasklogger.py
@@ -1,0 +1,22 @@
+import re
+import os
+import json
+import numpy as np
+
+example={'worker': 'tcp://10.180.4.206:42643', 'status': 'OK', 'nbytes': 28263552, 'thread': 140534840973056, 'type': b'\x80\x04\x95%\x00\x00\x00\x00\x00\x00\x00\x8c\x13cudf.core.dataframe\x94\x8c\tDataFrame\x94\x93\x94.', 'typename': 'cudf.core.dataframe.DataFrame', 'metadata': {}, 'startstops': ({'action': 'transfer', 'start': 1639787413.9825313, 'stop': 1639787413.998216, 'source': 'tcp://10.180.4.206:45115'}, {'action': 'compute', 'start': 1639787413.998873, 'stop': 1639787414.0106611}), 'key': "('drop-duplicates-combine-d121e7e64a9ef70e5616e411e95f2d3e', 1, 8, 0)"}
+
+class DaskTaskLogger():
+    key_expr=re.compile( '([\w-]+)-([0-9a-f-]{32,36})' )
+    
+    def __init__(self, client, outputdir='/tmp'):
+        self._client=client
+        self._outputdir=outputdir
+
+    def mark_begin( self ):
+        self._client.get_task_stream()
+
+    def save_tasks( self, prefix='dask' ):
+        plotfname=os.path.join(self._outputdir, f"{prefix}_plot.html")
+        pdata, pfigure = self._client.get_task_stream(plot='save', filename=plotfname)
+        with open( os.path.join(self._outputdir, f"{prefix}_tasks.json"), 'w') as outf:
+            json.dump([{k:t[k] for k in filter( lambda x: type(t[x]) != bytes().__class__, t)} for t in pdata],outf)

--- a/gpu_bdb/bdb_tools/rmm_monitor.py
+++ b/gpu_bdb/bdb_tools/rmm_monitor.py
@@ -1,0 +1,76 @@
+import os
+import csv
+import rmm
+import tempfile
+import asyncio
+
+from dask.distributed import Client, Worker, WorkerPlugin
+
+from typing import List
+
+
+class DependencyInstaller(WorkerPlugin):
+    def __init__(self, dependencies: List[str]):
+        self._depencendies = " ".join(f"'{dep}'" for dep in dependencies)
+
+    def setup(self, _worker: Worker):
+        os.system(f"conda install -c rapidsai-nightly -c rapidsai -c nvidia -c conda-forge -c defaults {self._depencendies}")
+
+# Wrap this in a method used to initialize the module + pass in teh client instance
+dependency_installer = DependencyInstaller(["pynvml"])
+
+#client = Client()
+#client.register_worker_plugin(dependency_installer)
+
+class RMMResourceMonitor:
+    """
+    Distributed montor for RMM resource allocations
+    """
+
+    def __init__( self, client, outputdir='/tmp'  ):
+        self._client = client if isinstance(client, Client) else None
+        self._outputdir=outputdir
+
+    def __dispatch__( self, method, **kwargs ):
+        if self._client:
+            self._client.run( method, **kwargs )
+        else:
+            return method(*args, **kwargs )
+
+    def get_remote_output_dir( self ):
+        return self._outputdir
+
+    def begin_logging( self, prefix="rmmlog"):
+        """
+        enable rmm logging into dask temporary directory
+        """
+
+        def _rmmlogstart( basedir, prefix ):
+            import os
+            rmm.enable_logging( log_file_name=os.path.join( basedir,  f"{prefix}_" + str(os.getpid())+".log"))
+
+        self.__dispatch__( _rmmlogstart, prefix=prefix, basedir=self.get_remote_output_dir())
+
+    def stop_logging( self ):
+        """
+        disable rmm logging and mark files for retrieval
+        """
+        def _rmmlogstop():
+            rmm.disable_logging()
+
+        self.__dispatch__( _rmmlogstop )
+
+    def collect( self ):
+        """
+        distributed command retrieves an logfile
+        @return reference to dataframe into which rresults are being loaded
+        """
+        def _collect():
+            for fname in (rmm.get_log_filenames()):
+                print( fname )
+                #load into memory and return dask_dataframe reference?
+
+        retval = DaskDataframe()
+        for lf_future in self.__dispatch__( _collect, localfile ):
+            pass
+

--- a/gpu_bdb/benchmark_runner.py
+++ b/gpu_bdb/benchmark_runner.py
@@ -28,7 +28,8 @@ bsql_qnums = [str(i).zfill(2) for i in range(1, 31)]
 if __name__ == "__main__":
     from bdb_tools.cluster_startup import attach_to_cluster, import_query_libs
     from bdb_tools.utils import run_query, gpubdb_argparser
-
+    from bdb_tools import RMMResourceMonitor
+    from bdb_tools import DaskTaskLogger
     import_query_libs()
     config = gpubdb_argparser()
     config["run_id"] = uuid.uuid4().hex
@@ -89,8 +90,17 @@ if __name__ == "__main__":
             with open("current_query_num.txt", "w") as fp:
                 fp.write(qnum)
 
+            rmm_analyzer=RMMResourceMonitor(client=client,
+                                            outputdir=os.getenv('OUTPUT_DIR', '/tmp'))
+            dasktasklog=DaskTaskLogger( client=client,
+                                        outputdir=os.getenv('OUTPUT_DIR', '/tmp'))
+            #FIXME: OUTPUT_DIR is not managed by gpu-bdb, might want to pick that up into the config
             for r in range(N_REPEATS):
+                rmm_analyzer.begin_logging( prefix=f"rmmlog{qnum}")
+                dasktasklog.mark_begin()
                 run_query(config=config, client=client, query_func=q_func)
+                rmm_analyzer.stop_logging()
+                dasktasklog.save_tasks( prefix=f"dasktasklog{qnum}")
                 client.run(gc.collect)
                 client.run_on_scheduler(gc.collect)
                 gc.collect()


### PR DESCRIPTION
Adds a couple of utilities to capture metrics per query triggered in benchmark_runner.py
rmm_monitor logs Cuda allocations from each dask worker
dask_task_logger grabs the tasks into a json file

TBD:
* gate with an environment variable as the logs add up quickly.
* mark rmm logs with worker ID