### PR TITLE
Update use of deprecated api for 22.04

### DIFF
--- a/gpu_bdb/bdb_tools/q05_utils.py
+++ b/gpu_bdb/bdb_tools/q05_utils.py
@@ -94,7 +94,7 @@ def build_and_predict_model(ml_input_df):
     results_dict = {}
     y_pred = model.predict(X)
 
-    results_dict["auc"] = roc_auc_score(y.to_array(), y_pred.to_array())
+    results_dict["auc"] = roc_auc_score(y.values_host, y_pred.values_host)
     results_dict["precision"] = cupy_precision_score(cp.asarray(y), cp.asarray(y_pred))
     results_dict["confusion_matrix"] = confusion_matrix(
         cp.asarray(y, dtype="int32"), cp.asarray(y_pred, dtype="int32")

--- a/gpu_bdb/bdb_tools/q18_utils.py
+++ b/gpu_bdb/bdb_tools/q18_utils.py
@@ -101,11 +101,12 @@ def find_targets_in_reviews_helper(ddf, targets, str_col_name="pr_review_content
     """
 
     lowered = ddf[str_col_name].str.lower()
-
+    tres = find_multiple.find_multiple(lowered._column, targets._column)
+    print(type(tres))
     ## TODO: Do the replace/any in cupy land before going to cuDF
     resdf = cudf.DataFrame(
         cp.asarray(
-            find_multiple.find_multiple(lowered._column, targets._column)
+            cudf.Series(find_multiple.find_multiple(lowered._column, targets._column)).explode()
         ).reshape(-1, len(targets))
     )
 

--- a/gpu_bdb/bdb_tools/q18_utils.py
+++ b/gpu_bdb/bdb_tools/q18_utils.py
@@ -101,8 +101,6 @@ def find_targets_in_reviews_helper(ddf, targets, str_col_name="pr_review_content
     """
 
     lowered = ddf[str_col_name].str.lower()
-    tres = find_multiple.find_multiple(lowered._column, targets._column)
-    print(type(tres))
     ## TODO: Do the replace/any in cupy land before going to cuDF
     resdf = cudf.DataFrame(
         cp.asarray(


### PR DESCRIPTION
Updates the use of `to_array` in query 05 since it was deprecated.

Updates the use of `find_multiple` in q18 since it now returns a list column instead of a host array (previous behavior). 