### PR TITLE
[WIP] Unify profile generation to include entirety of query run

### DIFF
--- a/gpu_bdb/bdb_tools/utils.py
+++ b/gpu_bdb/bdb_tools/utils.py
@@ -248,7 +248,7 @@ def run_query(
     config, client, query_func, write_func=write_result, sql_context=None
 ):
     if config.get("dask_profile"):
-        with performance_report(filename=f"profile.html"): 
+        with performance_report(filename="profile.html"): 
             if sql_context:
                 run_sql_query(
                     config=config,

--- a/gpu_bdb/bdb_tools/utils.py
+++ b/gpu_bdb/bdb_tools/utils.py
@@ -50,7 +50,6 @@ from oauth2client.service_account import ServiceAccountCredentials
 #################################
 def benchmark(func, *args, **kwargs):
     csv = kwargs.pop("csv", True)
-    dask_profile = kwargs.pop("dask_profile", False)
     compute_result = kwargs.pop("compute_result", False)
     name = func.__name__
     t0 = time.time()
@@ -288,7 +287,6 @@ def run_dask_cudf_query(config, client, query_func, write_func=write_result):
         config["start_time"] = time.time()
         results = benchmark(
             query_func,
-            dask_profile=config.get("dask_profile"),
             client=client,
             config=config,
         )
@@ -330,7 +328,6 @@ def run_sql_query(
         data_dir = config["data_dir"]
         results = benchmark(
             query_func,
-            dask_profile=config.get("dask_profile"),
             data_dir=data_dir,
             client=client,
             c=sql_context,


### PR DESCRIPTION
Currently, gpu-bdb only generates profiles for the `read_tables` and `main` functions. This means that when there are tasks that are created within  those functions, but not computed until the `write_result` function they don't show up in any profiles. This is why some queries like dask-sql query 14 generate completely empty profiles and other dask-sql queries generate incomplete profiles.

This PR unifies profile generation such that the entirety of the query run is encompassed in a single profile (now called `profile.html`). This way, all tasks executed within the `read_tables`, `main`, or `write_result` functions will be included in a single profile.