### PR TITLE
[WIP] Enable using CPU backend with first set of dask queries

### DIFF
--- a/gpu_bdb/bdb_tools/utils.py
+++ b/gpu_bdb/bdb_tools/utils.py
@@ -942,16 +942,22 @@ def left_semi_join(df_1, df_2, left_on, right_on):
 
 
 def convert_datestring_to_days(df):
- 
-    import cudf
+    if isinstance(df, cudf.DataFrame):
+        df["d_date"] = (
+            cudf.to_datetime(df["d_date"], format="%Y-%m-%d")
+            .astype("datetime64[s]")
+            .astype("int64")
+            / 86400
+        )
+        df["d_date"] = df["d_date"].astype("int64")
+    else:
+        df["d_date"] = (
+            pd.to_datetime(df["d_date"], format="%Y-%m-%d")
+            .view("int64")
+            / 8.64e+13
+        )
+        df["d_date"] = df["d_date"].astype("int64")
 
-    df["d_date"] = (
-        cudf.to_datetime(df["d_date"], format="%Y-%m-%d")
-        .astype("datetime64[s]")
-        .astype("int64")
-        / 86400
-    )
-    df["d_date"] = df["d_date"].astype("int64")
     return df
 
 


### PR DESCRIPTION
This PR enables using the CPU backend option with Dask queries: 01, 06, 07, 09 11, 12,13,14,15,16,20,21, 22, 23, 24, 29 as well as dask-sql query 22.

Query 17 is a WIP