### PR TITLE
Revert "Adding queries 25, 26 and 30 to be reviewed"

### DIFF
--- a/gpu_bdb/bdb_tools/q25_utils.py
+++ b/gpu_bdb/bdb_tools/q25_utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import dask.dataframe as dd
 import dask_cudf
 
 from bdb_tools.utils import train_clustering_model
@@ -34,7 +33,6 @@ def read_tables(config, c=None):
         data_format=config["file_format"],
         basepath=config["data_dir"],
         split_row_groups=config["split_row_groups"],
-        backend=config["backend"],
     )
 
     ss_cols = ["ss_customer_sk", "ss_sold_date_sk", "ss_ticket_number", "ss_net_paid"]
@@ -67,15 +65,10 @@ def get_clusters(client, ml_input_df):
     results_dict = client.compute(*ml_tasks, sync=True)
 
     output = ml_input_df.index.to_frame().reset_index(drop=True)
-    
-    if isinstance(ml_input_df, cudf.DataFrame):
-        labels_final = dask_cudf.from_cudf(
-            results_dict["cid_labels"], npartitions=output.npartitions
-        )
-    else:
-         labels_final = dd.from_cudf(
-            results_dict["cid_labels"], npartitions=output.npartitions
-        )
+
+    labels_final = dask_cudf.from_cudf(
+        results_dict["cid_labels"], npartitions=output.npartitions
+    )
     output["label"] = labels_final.reset_index()[0]
 
     # Sort based on CDH6.1 q25-result formatting

--- a/gpu_bdb/bdb_tools/q26_utils.py
+++ b/gpu_bdb/bdb_tools/q26_utils.py
@@ -26,7 +26,6 @@ def read_tables(config, c=None):
         data_format=config["file_format"],
         basepath=config["data_dir"],
         split_row_groups=config["split_row_groups"],
-        backend=config["backend"],
     )
 
     ss_cols = ["ss_customer_sk", "ss_item_sk"]

--- a/gpu_bdb/bdb_tools/q30_utils.py
+++ b/gpu_bdb/bdb_tools/q30_utils.py
@@ -28,7 +28,6 @@ def read_tables(config, c=None):
         data_format=config["file_format"],
         basepath=config["data_dir"],
         split_row_groups=config["split_row_groups"],
-        backend=config["backend"],
     )
 
     item_cols = ["i_category_id", "i_item_sk"]

--- a/gpu_bdb/queries/q25/gpu_bdb_query_25_dask_sql.py
+++ b/gpu_bdb/queries/q25/gpu_bdb_query_25_dask_sql.py
@@ -36,11 +36,8 @@ from bdb_tools.q25_utils import (
 from dask import delayed
 
 def get_clusters(client, ml_input_df):
-    import dask.dataframe as dd
     import dask_cudf
-    import cudf
-    import pandas as pd
-    
+
     ml_tasks = [
         delayed(train_clustering_model)(df, N_CLUSTERS, CLUSTER_ITERATIONS, N_ITER)
         for df in ml_input_df.to_delayed()
@@ -48,16 +45,10 @@ def get_clusters(client, ml_input_df):
     results_dict = client.compute(*ml_tasks, sync=True)
 
     output = ml_input_df.index.to_frame().reset_index(drop=True)
-    
-    if isinstance(ml_input_df, cudf.DataFrame):
-        labels_final = dask_cudf.from_cudf(
-            results_dict["cid_labels"], npartitions=output.npartitions
-        )
-    else:
-        labels_final = dd.from_pandas(
-            pd.DataFrame(results_dict["cid_labels"]), npartitions=output.npartitions
-        )
-        
+
+    labels_final = dask_cudf.from_cudf(
+        results_dict["cid_labels"], npartitions=output.npartitions
+    )
     output["label"] = labels_final.reset_index()[0]
 
     # Based on CDH6.1 q25-result formatting


### PR DESCRIPTION
Reverts rapidsai/gpu-bdb#241

We should revert the changes pushed in this PR as : 


1. Q25 and Q26 changes are buggy and introduce the following error.  

```python
Traceback (most recent call last):
  File "/datasets/vjawa/miniconda3/envs/rapids-gpu-bdb-dask-sql-feb-11/lib/python3.8/site-packages/bdb_tools/utils.py", line 334, in run_sql_query
    results = benchmark(
  File "/datasets/vjawa/miniconda3/envs/rapids-gpu-bdb-dask-sql-feb-11/lib/python3.8/site-packages/bdb_tools/utils.py", line 57, in benchmark
    result = func(*args, **kwargs)
  File "gpu_bdb_query_25_dask_sql.py", line 188, in main
    results_dict = get_clusters(client=client, ml_input_df=cluster_input_ddf)
  File "gpu_bdb_query_25_dask_sql.py", line 58, in get_clusters
    pd.DataFrame(results_dict["cid_labels"]), npartitions=output.npartitions
  File "/datasets/vjawa/miniconda3/envs/rapids-gpu-bdb-dask-sql-feb-11/lib/python3.8/site-packages/pandas/core/frame.py", line 684, in __init__
    data = list(data)
  File "/home/nfs/vjawa/gpu_bdb_latest/dask-cuda/dask_cuda/proxy_object.py", line 560, in __iter__
    return iter(self._pxy_deserialize())
  File "/datasets/vjawa/miniconda3/envs/rapids-gpu-bdb-dask-sql-feb-11/lib/python3.8/site-packages/cudf/utils/utils.py", line 209, in __iter__
    raise TypeError(
TypeError: Series object is not iterable. Consider using `.to_arrow()`, `.to_pandas()` or `.values_host` if you wish to iterate over the values.

```

This is because the following should check for `dask_cudf` and not `cudf`. 

https://github.com/rapidsai/gpu-bdb/blob/9ae8a4d6dd1f682d6bb7cc5c93ab32b5144da10c/gpu_bdb/queries/q25/gpu_bdb_query_25_dask_sql.py#L52-L55


2.  The ML component still uses cuML so uses GPUs so this not really a legit CPU implementation for these queries. 

https://github.com/rapidsai/gpu-bdb/blob/9ae8a4d6dd1f682d6bb7cc5c93ab32b5144da10c/gpu_bdb/bdb_tools/utils.py#L958-L994

CC: @DaceT , @ayushdg 
