### PR TITLE
Fix result writing

### DIFF
--- a/gpu_bdb/bdb_tools/utils.py
+++ b/gpu_bdb/bdb_tools/utils.py
@@ -299,7 +299,7 @@ def run_dask_cudf_query(config, client, query_func, write_func=write_result):
         benchmark(
             write_func,
             results,
-            output_directory=config["output_dir"],
+            output_directory=config["output_dir"] or "./",
             filetype=config["output_filetype"],
         )
         config["query_status"] = "Success"
@@ -342,7 +342,7 @@ def run_sql_query(
         benchmark(
             write_func,
             results,
-            output_directory=config["output_dir"],
+            output_directory=config["output_dir"] or "./",
             filetype=config["output_filetype"],
         )
         config["query_status"] = "Success"

--- a/gpu_bdb/bdb_tools/utils.py
+++ b/gpu_bdb/bdb_tools/utils.py
@@ -299,7 +299,7 @@ def run_dask_cudf_query(config, client, query_func, write_func=write_result):
         benchmark(
             write_func,
             results,
-            output_directory=config["output_dir"] or "./",
+            output_directory=config["output_dir"],
             filetype=config["output_filetype"],
         )
         config["query_status"] = "Success"
@@ -342,7 +342,7 @@ def run_sql_query(
         benchmark(
             write_func,
             results,
-            output_directory=config["output_dir"] or "./",
+            output_directory=config["output_dir"],
             filetype=config["output_filetype"],
         )
         config["query_status"] = "Success"
@@ -393,7 +393,7 @@ def gpubdb_argparser():
     # if yaml configuration missing
     KEYS_TO_ENV_VAR_MAPPING = {
         "data_dir": os.environ.get("DATA_DIRECTORY"),
-        "output_dir": os.environ.get("OUTPUT_DIRECTORY"),
+        "output_dir": os.environ.get("OUTPUT_DIRECTORY", "./"),
         "sheet": os.environ.get("GOOGLE_SPREADSHEET_NAME"),
         "tab": os.environ.get("GOOGLE_SPREADSHEET_TAB"),
         "scheduler_file_path": os.environ.get("SCHEDULER_FILE"),


### PR DESCRIPTION
This fixes an issue where results files have incorrect names when the `output_directory` configuration option is left blank. For example,  without this fix, query 10 writes its results to `Noneq10-results.parquet` instead of `q10-results.parquet`.

Closes #260 