### PR TITLE
Remove a duplicate entry in yml file

### DIFF
--- a/conda/rapids-gpu-bdb-dask-sql-cuda11.2.yml
+++ b/conda/rapids-gpu-bdb-dask-sql-cuda11.2.yml
@@ -27,7 +27,6 @@ dependencies:
   - ipykernel
   - jupyterlab
   - gspread
-  - oauth2client
   - pytest
   - pip
   - pip:


### PR DESCRIPTION
This PR removes a duplicate occurrence of `oauth2client` in yml file.